### PR TITLE
General improvements of several class N antenna sections.

### DIFF
--- a/contents/sections/dipol.md
+++ b/contents/sections/dipol.md
@@ -1,4 +1,4 @@
-Die Grundform der Antenne ist die *Dipol-Antenne* (Abbildung [ref:n_dipol]). Sie wird von Funkamateuren in Kurzform auch einfach als Dipol bezeichnet. Ein Dipol besteht aus zwei Teilen, üblicherweise sind dies Drähte oder Metallstäbe. Einer der Leiter des Antennenkabels wird an das eine Teil, der andere Leiter an das andere Teil angeschlossen.
+Die Grundform der Antenne ist die *Dipol-Antenne* (Abbildung [ref:n_dipol]). Sie wird abgekürzt meist einfach als *Dipol* bezeichnet. Ein Dipol besteht aus zwei länglichen Teilen, üblicherweise sind dies Drähte oder Metallstäbe. Einer der Leiter des Antennenkabels wird an das eine Teil, der andere Leiter an das andere Teil angeschlossen.
 
 <margin>
 [picture:589:n_dipol:Darstellung einer Dipol-Antenne]
@@ -8,34 +8,36 @@ Die Grundform der Antenne ist die *Dipol-Antenne* (Abbildung [ref:n_dipol]). Sie
 Der Begriff *Dipol* kommt aus dem Griechischen und bedeutet soviel wie "Zweipol".
 </wordorigin>
 
----
-
-In der Praxis wird häufig der sogenannte Halbwellendipol verwendet, der eine Länge von $\lambda / 2$ aufweist, also einer halben Wellenlänge. Beispiel: Im 10 m-Band beträgt die Wellenlänge rund 10 m. Die halbe Wellenlänge ist demnach 5 m. Ein Halbwellendipol für das 10 m-Band hat also 5 m lang zu sein. Jedes Teilstück muss daher eine Länge von ca. 2,5 m haben. Man spricht dann davon, dass der Halbwellendipol in *Resonanz* ist.
-
-<indepth>
-Es gibt auch andere *Varianten der Dipol-Antenne*, beispielsweise den Ganzwellendipol, den verkürzten Dipol oder den asymmetrisch gespeisten Dipol, bei dem das Antennenkabel nicht in der Mitte angeschlossen wird und die beiden Teile entsprechend unterschiedlich lang sind.
-</indepth>
-
----
-
-Ein Dipol der richtigen Länge hat eine gute *Abstrahlung*. Er gibt bei Sendebetrieb möglichst viel der elektrischen Schwingung als Funkwelle ab bzw. nimmt beim Empfang möglichst viel von einer Funkwelle als elektrische Schwingung auf. Verwendet man den Dipol auf höheren oder niedrigeren Frequenzen, dann funktioniert er zunehmend schlechter.
-
-<indepth>
-*Resonanz* gibt es nicht nur bei Antennen, sondern beispielsweise auch bei Instrumenten in der Musik. Dies wird am Beispiel von Kontrabass und Geige deutlich: Ein Kontrabass hat vergleichsweise lange Saiten und erzeugt tiefe Töne, also tiefe Frequenzen. Eine Geige hingegen hat eher kurze Saiten und erzeugt hohe Töne, also hohe Frequenzen. Bei Antennen ist es im Prinzip genauso. Lange Dipol-Antennen eignen sich für tiefe Frequenzen und kurze Dipol-Antennen für hohe Frequenzen.
-</indepth>
-
 [question:NG103]
 
-Liegt die Resonanzfrequenz unterhalb der gewünschten Frequenz, dann ist der Dipol zu lang. Die Dipol-Antenne kann auf die gewünschte Frequenz gebracht werden, indem man sie an beiden Seiten gleichmäßig kürzt.
+---
 
-[question:NG304]
+In der Praxis wird häufig der sogenannte Halbwellendipol verwendet, der ungefähr $\lambda / 2$ lang ist, also so lang wie eine halben Wellenlänge. Beispiel: Im 10 m-Band beträgt die Wellenlänge rund 10 m. Die halbe Wellenlänge ist demnach etwa 5 m. Ein Halbwellendipol für das 10 m-Band wird also etwa 5 m lang sein, jede Hälfte etwa 2,5 m.
 
 ---
+
+Bei der richtigen Länge von ungefähr einer halben Wellenlänge (in Wirklichkeit ein Weniges kürzer) ist der Halbwellendipol in *Resonanz*. Dann ist er vom Funkgerät besonders einfach zu speisen.
+
+<indepth>
+*Resonanz* gibt es nicht nur bei Antennen, sondern beispielsweise auch bei Musikinstrumenten, zum Beispiel bei Kontrabass und Geige: Ein Kontrabass hat vergleichsweise lange Saiten und erzeugt tiefe Töne, also tiefe Frequenzen. Eine Geige hingegen hat eher kurze Saiten und erzeugt hohe Töne, also hohe Frequenzen. Bei Antennen ist es ähnlich: Lange Dipol-Antennen haben ihre Halbwellenresonanz bei tiefen Frequenzen und kurze bei hohen.
+</indepth>
+
+Liegt die Resonanzfrequenz unterhalb der gewünschten Frequenz, dann ist der Dipol zu lang. So ein Dipol kann auf die gewünschte Resonanzfrequenz gebracht werden, indem er an beiden Enden gleichmäßig gekürzt wird.
+
+[question:NG304]
 
 Andersherum kann eine zu hohe Resonanzfrequenz eines Dipols nach unten verändert werden, indem man beide Seiten gleichmäßig verlängert.
 
 <tip>
-Ein Draht oder Metallstab lässt sich viel einfacher kürzen als verlängern. Daher ist es beim Bau eines Dipols zweckmäßig ihn zunächst etwas länger als berechnet auszulegen und dann schrittweise vorsichtig zu kürzen, bis Resonanz erreicht ist.
+Ein Draht oder Metallstab lässt sich viel einfacher kürzen als verlängern. Daher wird eine Dipol meist zunächst etwas länger als berechnet ausgelegt und dann schrittweise vorsichtig gekürzt, bis Resonanz bei der gewünschten Frequenz erreicht ist.
 </tip>
 
 [question:NG305]
+
+<indepth>
+Bei Kontrabass oder Geige lässt sich die Resonanzfrequenz einer Saite in einem weiten Bereich verändern, indem sie mehr oder weniger gespannt wird. Ähnlich kann ein Dipol fester Länge durch elektrische Maßnahmen über einen weiten Frequenzbereich resonant gemacht werden.
+</indepth>
+
+<indepth>
+Es gibt neben den Halbwellendipolen auch andere *Varianten der Dipol-Antenne*, beispielsweise den doppelt so langen Ganzwellendipol oder den verkürzten Dipol. Weiter gibt es asymmetrisch gespeisten Dipole, bei denen die beiden Dipolteile unterschiedlich lang sind und also das Antennenkabel außerhalb der Mitte angeschlossen wird.
+</indepth>

--- a/contents/sections/endgespeiste_antennen.md
+++ b/contents/sections/endgespeiste_antennen.md
@@ -4,28 +4,28 @@ Anstatt in der Mitte kann man das Antennenkabel auch an einem Ende des Dipols an
 [picture:615:n_antennenformen_schaltbild_endfed:Schaltbild einer endgespeisten Antenne]
 </margin>
 
-Eine häufige Bauform ist der endgespeiste Halbwellendipol. Die Länge des Drahtes beträgt dann $\lambda / 2$, entsprechend der Gesamtlänge des normalen Halbwellendipols. Damit die Antenne funktioniert, muss ein spezielles Anpassglied verwendet werden. 
+Eine häufige Bauform ist der endgespeiste Halbwellendipol. Der Draht wird wieder etwa $\lambda / 2$ lange gemacht wie beim Halbwellendipol. Damit die Antenne funktioniert, wird ein spezielles Anpassglied verwendet.
+
+<tip>
+Die End-Fed ist eine beliebte Antennenbauform. Es erleichtert oft den Aufbau, dass der Antennenanschluss nicht im Mittelpunkt, sondern an einem der Enden liegt.
+</tip>
 
 <indepth>
-% TODO: Editionsspezifisch machen
-Das *Anpassglied* ist erforderlich, da die Antenne im Gegensatz zu den bisher vorgestellten Antennen nicht über den richtigen Speisewiderstand verfügt. 
-Was das ist, behandeln wird im weiteren Verlauf dieses Kapitels. Wie ein Anpassglied funktioniert, wird im Kurs für Klasse E erklärt.
+Das *Anpassglied* ist erforderlich, da die Antenne im Gegensatz zu den bisher vorgestellten Antennen nicht über den für den Sender passenden Speisewiderstand verfügt.
+
+Den Speisewiderstand behandeln wird im weiteren Verlauf dieses Kapitels. Wie ein Anpassglied funktioniert, wird im Kurs für Klasse E erklärt.
 </indepth>
 
 <indepth>
-Die End-Fed ist eine beliebte Antennenbauform. Sie hat den Vorteil, dass der Anschluss der Speiseleitung nicht am Mittelpunkt, sondern an einem der Enden erfolgt.
-</indepth>
-
-<indepth>
-Wo ist eigentlich das *Gegengewicht bei der End-Fed-Antenne*? Wir haben ja gelernt, dass eine Antenne immer aus zwei Teilen besteht. Bei der endgespeisten Antenne wird oft ein Teil der Speiseleitung als Gegengewicht genutzt. Das kann jedoch zu Störungen bei elektrischen Geräten und auch in der eigenen Funkanlage führen. Solche Störungen können beispielsweise durch ein $\lambda / 4$-langes Radial als Gegengewicht, eine gute Verbindung zur Erde und Verwendung einer Mantelwellensperre vermieden werden.
+Wo ist eigentlich das *Gegengewicht bei der End-Fed-Antenne*? Wir haben ja gelernt, dass eine Antenne immer aus zwei Teilen besteht. Im Bild oben ist das Anpassglied geerdet, dann wirkt die Erde als Gegengewicht. Alternativ wird bei endgespeisten Antennen machmal ein Teil der Speiseleitung als Gegengewicht genutzt. Das funktioniert oft, führt aber auch schnell dazu, dass beim Senden HF-Ströme vagabundieren und elektrische Geräte einschließlich der eigenen Funkanlage stören. Solche Störungen können durch ein $\lambda / 4$-langes Radial oder ein Erdnetz aus Radials vermieden werden. Zusätzlich hilft eine Mantelwellensperre oft; was eine Mantelwellensperre ist, wird [im E-Kurs](E_mantelwellen_1.html) erklärt.
 </indepth>
 
 [question:NG107]
 
-Im Kurzwellenbereich werden oft besonders lange endgespeiste Antennen benutzt. Eine endgespeiste Antenne, deren Draht länger als $\lambda$ ist, nennt man *Langdraht-Antenne*.  Im VHF/UHF-Bereich werden üblicherweise keine Langdrahtantennen benutzt.
+Im Kurzwellenbereich werden manchmal besonders lange endgespeiste Antennen benutzt. Eine endgespeiste Antenne, deren Draht länger als $\lambda$ ist, nennt man *Langdraht-Antenne*.  Für Nutzung im VHF/UHF-Bereich sind Langdrahtantennen unüblich.
 
 <indepth>
-Der Begriff *Langdraht-Antenne* wird machmal auch fälschlicherweise für den endgespeisten Halbwellendipol benutzt, obwohl dieser kürzer als $\lambda$ ist.
+Der Begriff *Langdraht-Antenne* wird machmal für endgespeiste Halbwellendipole inkorrekt benutzt, obwohl diese kürzer als $\lambda$ ist.
 </indepth>
 
 [question:NG109]

--- a/contents/sections/rundstrahler.md
+++ b/contents/sections/rundstrahler.md
@@ -1,23 +1,29 @@
-Wenn man einen Teil eines Dipols senkrecht nach oben und den anderen parallel zum Erdboden ausrichtet, erhält man eine "Up- and Outer"-Antenne (Abbildung [ref:n_up_and_outer]). Den senkrechten Teil dieser Antenne bezeichnet man als *Strahler*, den waagerechten Teil als *Radial* oder *Gegengewicht*.
+Wenn man einen Teil eines Dipols senkrecht nach oben und den anderen parallel zum Erdboden ausrichtet, erhält man eine "Up- and Outer"-Antenne (Abbildung [ref:n_up_and_outer]). Die Up- and Outer-Antenne wird auch als *Upper and Outer* bezeichnet. Den senkrechten Teil dieser Antenne bezeichnet man als *Strahler*, den waagerechten Teil als *Radial* oder *Gegengewicht*.
 
 <margin>
 [picture:659:n_up_and_outer:Up- and Outer-Antenne]
 </margin>
 
-<indepth>
-Auch wenn der senkrechte Teil von Vertikalantennen wie der Up- and Outer-Antenne als *Strahler* bezeichnet wird, bedeutet das nicht, dass er das einzige Teil der Antenne ist, das die Funkwelle abstrahlt. Vielmehr wird die Funkwelle von Gesamtgebilde bestehend aus Strahler und Gegengewicht abgegeben. Nur bei bestimmten Bauformen wird abgestrahlte Welle fast ausschließlich vom Strahler bestimmt, beispielsweise bei einer Groundplane mit horizontal und exakt symmetrisch angeordneten Gegengewichten. Doch auch bei diesen Antennen bildet sich an den Gegengewichten unter Umständen ein sogenanntes "Nahfeld" aus, welches hohe Feldstärken aufweisen kann. Aus diesem Grunde sind Radials bei der Betrachtung des Sicherheitsabstands stets mit zu berücksichtigen.
-</indepth>
+Die Up- and Outer-Antenne gehört zu den sogenannten Vertikalantennen, da der Strahler senkrecht (vertikal) angeordnet ist. Wie beim Dipol beträgt die Länge beider Teile der Up- and Outer-Antenne zusammen etwa $\lambda{} / 2$, also etwa eine halbe Wellenlänge. Der Strahler und das Gegengewicht sind also jeweils etwa $\lambda{} / 4$ lang.
 
-Die Up- and Outer-Antenne gehört zu den sogenannten Vertikalantennen, da der Strahler senkrecht (vertikal) angeordnet ist. Wie beim Dipol beträgt die Länge beider Teile der Up- and Outer-Antenne zusammen $\lambda{} / 2$, also eine halbe Wellenlänge. Der Strahler und das Gegengewicht sind demzufolge also jeweils $\lambda{} / 4$ lang.
+---
 
-Wird das parallel zum Erdboden geführte Radial nun vervielfacht, dann entsteht eine *Groundplane-Antenne*, die im Amateurfunk häufig verwendet wird.
+Wird das Radial vervielfacht, entsteht eine *Groundplane-Antenne*. Groundplane-Antennen werden im Amateurfunk häufig verwendet. Die Radiale können parallel zum Erdboden geführt werden, bei VHF/UHF-Groundplanes sind sie oft nach unten abgewinkelt.
 
 [question:NG105]
 [question:NG106]
 
+<indepth>
+Der senkrechte Teil einer Vertikalantennen wie der Up- and Outer wird als *Strahler* bezeichnet. Er ist aber nicht der einzige Teil der Antenne, der Funkwellen abstrahlt oder empfängt. Die Funkwelle wird von Gesamtgebilde abgegeben oder aufgenommen, das aus Strahler und Gegengewicht besteht.
+
+Bei bestimmten Bauformen wird fast nur vom Strahler gesendet oder empfangen. Eine solche Bauform ist eine Groundplane, deren Gegengewichte horizontal und symmetrisch sind. Aber auch bei ihr bildet sich beim Senden um die Gegengewichte ein sogenanntes "Nahfeld" aus, das hohe Feldstärken erreichen kann.
+
+Geht es um Sicherheitsabstände, die von sendenden Antennen einzuhalten sind, sind Radials grundsätzlich mit zu berücksichtigen.
+</indepth>
+
 ---
 
-Man kann das Radial einer Up- and Outer-Antenne auch durch den Erdboden ersetzen. Dann erhält man die in Abbildung [ref:n_marconi_antenne] gezeigte *Marconi-Antenne*. Das Gegengewicht, also der zweite Teil der Antenne, wird jetzt durch die *Erde* gebildet, die im Idealfall sehr gut leitet. Für die Darstellung der Erde wird in Schaltbildern das in Abbildung [ref:n_schaltzeichen_erde] gezeigte Symbol verwendet.
+Man kann das Radial einer Up- and Outer-Antenne auch durch den Erdboden ersetzen. Dann erhält man die in Abbildung [ref:n_marconi_antenne] gezeigte *Marconi-Antenne*. Das Gegengewicht, also der zweite Teil der Antenne, wird jetzt durch die *Erde* gebildet. Für die Darstellung der Erde wird in Schaltbildern das in Abbildung [ref:n_schaltzeichen_erde] gezeigte Symbol verwendet.
 
 <margin>
 [picture:669:n_marconi_antenne:Marconi-Antenne]
@@ -27,18 +33,16 @@ Man kann das Radial einer Up- and Outer-Antenne auch durch den Erdboden ersetzen
 [picture:544:n_schaltzeichen_erde:Schaltzeichen für Erde]
 </margin>
 
-<tip>
-In der Praxis ist es manchmal gar nicht so einfach, eine gute Verbindung zwischen Antennenkabel und der *Erde* herzustellen. Im einfachsten Fall verwendet man einen Erdnagel: Ein Metallstab wird in den Erdboden gesteckt und anstelle des Radials mit dem Antennenkabel verbunden. Etwas aufwändiger - aber oft auch wirkungsvoller - ist es beispielsweise, viele Drähte im Erdboden zu vergraben und diese wie Radials einer Groundplane rund um die Antennen anzuordnen. So kann eine gute Verbindung zur Erde hergestellt werden, die auch für Hochfrequenz geeignet ist.
-</tip>
+<indepth>
+In der Praxis ist es gar nicht so einfach, eine gute Verbindung zwischen Antennenkabel und der *Erde* herzustellen. Man kann es mit einen sogenannten Erdnagel versuchen: Ein langer Metallstab wird in den Erdboden gerammt und anstelle der Radials mit dem Antennenkabel verbunden. Das funktioniert in aller Regel nur sehr unbefriedigend. Aufwändiger, aber wirkungsvoller ist es, viele Drähte im Erdboden zu vergraben und diese wie Radials einer Groundplane rund um die Antennen anzuordnen. So kann eine gute Verbindung zur Erde hergestellt werden, die auch für Hochfrequenz funktioniert.
+</indepth>
 
-Wie bei der Up- and Outer-Antenne ist der vertikale Strahler der Marconi-Antenne $\lambda{} / 4$ lang. Da anstelle eines Gegengewichts die Erde verwendet wird, kann man die Marconi-Antenne auch als eine "gegen Erde erregte $\lambda{} / 4$-Vertikalantenne" beschreiben.
+Wie bei der Up- and Outer-Antenne ist der vertikale Strahler der Marconi-Antenne etwa $\lambda{} / 4$ lang. Da anstelle eines Gegengewichts die Erde verwendet wird, kann man die Marconi-Antenne auch als eine "gegen Erde erregte $\lambda{} / 4$-Vertikalantenne" beschreiben.
 
 [question:NG104]
 [question:NG102]
 
-Sowohl die Groundplane- als auch die Marconi-Antenne strahlen gleichmäßig in alle Himmelsrichtungen. Deshalb nennt man diese beiden Antennen auch "Rundstrahler". Im Gegensatz zu Richtantennen eignen sich Rundstrahler, um Funkamateure oder Relaisfunkstellen in unterschiedlichen Richtungen im Umkreis zu erreichen. Eine Richtantenne müsste immer wieder neu ausgerichtet werden.
-
-Damit ein Rundstrahler gut funktionert, sollte er möglichst hoch und rundherum frei positioniert werden. Die optimale Position ist daher auf einem hohem Mast, der umgebende Gebäude und Bäume überragt, oder dem Hausdach.
+Sowohl die Groundplane- als auch die Marconi-Antenne strahlen gleichmäßig in alle Himmelsrichtungen in die Ferne. Antennen, die das tun, nennt man "Rundstrahler". Im Gegensatz zu Richtantennen eignen sich Rundstrahler, um Funkamateure oder Relaisfunkstellen in unterschiedlichen Richtungen gleichzeitig zu erreichen oder zu hören. Eine Richtantenne müsste dazu immer wieder neu ausgerichtet werden.
 
 [question:NG110]
 
@@ -46,7 +50,6 @@ Damit ein Rundstrahler gut funktionert, sollte er möglichst hoch und rundherum 
 
 [question:NG111]
 
-<indepth>
-Die in der falschen Antwort erwähnten *Magnetfußantennen* werden übrigens gerne für mobilen Funkbetrieb auf einem Autodach betrieben. Das Autodach bildet dann - ähnlich der Erde bei der Marconi-Antenne - das Gegengewicht. Auf den Funkbetrieb aus Kraftfahrzeugen werden wir im Kapitel Einbau Kfz noch näher eingehen.
-</indepth>
+Die in der falschen Antwort erwähnten *Magnetfußantennen* werden übrigens gerne für mobilen VHF/UHF-Funkbetrieb aufs Autodach gesetzt. Das Blech des Daches bildet dann das Gegengewicht, ähnlich wie die Erde bei der Marconi-Antenne. Wird eine Magetfußantenne ohne größere Metallfläche betrieben, zum Beispiel auf dem Dachboden eines Hauses, fehlt ihr das Gegengewicht und sie funktioniert nicht gut.
 
+Auf Magnetfussantennen werden wir im Abschnitt [Einbau Kfz](N_einbau_kfz.html) noch näher eingehen.

--- a/contents/sections/yagi_uda_1.md
+++ b/contents/sections/yagi_uda_1.md
@@ -1,8 +1,12 @@
-Wenn man hinter und vor einem Dipol leitende Stäbe geschickt anordnet, entsteht eine *Yagi-Uda-Antenne*. Diese bündelt die Funkwellen beim Senden in eine bestimmte Richtung und nimmt beim Empfang die Funkwellen aus dieser Richtung besonders gut auf. Yagi-Uda-Antennen gehören zu den *Richtantennen*, da man sie auf die Gegenstation ausrichtet, mit der man funkt. Der Effekt von Richtantennen ist vergleichbar mit dem gebündelten Licht aus einer Taschenlampe oder einem Scheinwerfer.
+Werden hinter und vor einem Dipol leitende Stäbe geschickt angeordnet, entsteht eine *Yagi-Uda-Antenne*. Diese bündelt die Funkwellen beim Senden in eine bestimmte Richtung und nimmt beim Empfang die Funkwellen aus dieser Richtung besonders gut auf. Yagi-Uda-Antennen gehören zu den *Richtantennen*, da man sie auf die Gegenstation ausrichtet, mit der man funkt.
 
 <person>
 Die Yagi-Uda-Antenne ist nach ihren Erfindern, den japanischen Wissenschaftlern *Hidetsugu Yagi* und *Shintaro Uda* benannt, die ihre Entdeckung erstmals im Jahre 1926 veröffentlicht haben.
 </person>
+
+<indepth>
+Richtantennen senden besonders stark in eine Richtung, ähnlich wie eine Taschenlampe oder ein Scheinwerfer mit ihren Lichtbündeln in eine Richtung leuchten. Beim Empfang ist eine Richtantennen für Signale aus derselben Richtung besonders empfindlich, vergleichbar mit einem lichtstarken Fernrohr oder Teleskop. Richtantennen sind meist deutlich größer und unhandlicher als Dipole.
+</indepth>
 
 [question:NG108]
 


### PR DESCRIPTION
Major details:

- Simpler language, more verbs, less substantives, fewer unneeded words.
- Optimized sequence of the contents.
- Half-wave resonance happens at *approximately* half-wave wire length. We don't want people to cut half-wave dipols by theoretical length and expect it to work.
- Removed the factual error that too short and especially too long dipoles are radiating badly. We don't want to nurture the preception that resonant antennas are somehow magically "better". Let's just not get into this topic for class N.
- Better introduction and treatment of "resonance": Easier to feed, not magically better.
- Mention typical VHF/UHF ground plane with sloped radials. The previous text correctly restricted "radials don't radiate" to horizontal symmetrical radials, but never mentioned that radials can also be sloped. This could result in some confusion.
- Warn to not use a metal grounding rod as a Marconi antenna's earth. Such rods typically provide a miserable high frequency ground.
- The text has some remarks "high omnidirectional antennas are good". That is mostly true for VHF/UHF antennas, not just omnidirectional. Mostly. Many people don't know this, but for VHF/UHF, medium-height antennas often perform worse than lower ones. For short-wave antennas, the situation becomes even more complicated. Removed this entire discussion, as not fit for class N.
- Improved the introduction and treatment of omnidirctional antennas.
- Improved treatment of car antennas held by magnets; spell out why the wrong answer is wrong.
- Directional antennas exhibit gain not only when sending, but also when receiving.