### PR TITLE
Warn about using the DARCdown tags like one would a normal HTML tag.

### DIFF
--- a/README-FORMAT.md
+++ b/README-FORMAT.md
@@ -54,7 +54,13 @@ Tabellen werden mit senkrechten Strichen "gemalt". Der senkrechte Strich ist auf
 * Nur im LaTeX, nicht im Web: `<latexonly>...</latexonly>`
 
 > [!WARNING]
-> Es gibt eine Funktionseinschränkung im DARCdown Parser: Zumindest die Tags `<latexonly>...</latexonly>` und `<webonly>...</webonly>`, vielleicht auch die anderen, funktionieren zur Zeit nur, wenn das öffnende und das schließende Tag jeweils alleine auf einer Zeile steht.
+> Die Tags funktionieren nur, wenn das öffnende und schließende Tag jeweils für sich auf einer Zeile stehen:
+>
+> ```
+> <attention>
+> Bitte aufpassen!
+> </attention>
+> ```
 
 ## Aufzählungen
 


### PR DESCRIPTION
Each needs to stand on a line of their own.

Learned this from https://github.com/DARC-e-V/50ohm/issues/83#issuecomment-3868064173 but consider it is better documented here then there.