### PR TITLE
Add colons to table headers to hide alignment characters

### DIFF
--- a/contents/sections/frequenzspektrum.md
+++ b/contents/sections/frequenzspektrum.md
@@ -7,7 +7,7 @@
 Der Frequenzbereich elektromagnetischer Wellen ist sehr groß (Abbildung [ref:n_frequenzspektrum]). Für Funkwellen wird nur ein Teil dieses Spektrums genutzt, üblicherweise der Frequenzbereich zwischen 30 kHz und 300 GHz. In der Tabelle [ref:n_frequenzspektrum_bereiche] ist zu sehen, welche Frequenzen welchen Bereichen zugeordnet sind. Den Frequenzbereichen werden Abkürzungen zugeordnet. Für die Prüfung müssen  die Frequenzbereiche von 3 MHz bis 3000 MHz den entsprechenden Begriffen zugeordnet werden können.
 
 <webmargin>
-| r | c |  r | X | l |
+| r: | c: | r: | X: | l: |
 | von | | bis | Bezeichnung | Abk. |
 | 30 kHz | - | 300 kHz | Low Frequency | LF |
 | | | | (Langwelle) | (LW) |

--- a/contents/sections/funkfernschreiben.md
+++ b/contents/sections/funkfernschreiben.md
@@ -28,7 +28,7 @@ BK QSL = VY 73 DE DL2AB SK
 </qso>
 
 <webmargin>
-| l | X |
+| l: | X: |
 | Abkz. | Bedeutung |
 | BK | Unterbrechung der Sendung; Formlose Übergabe |
 | CQ | Allgemeiner Anruf |

--- a/contents/sections/locator.md
+++ b/contents/sections/locator.md
@@ -29,7 +29,7 @@ Eigentlich sind die Quadrate (squares) des Maidenhead-Locator gar keine Quadrate
 
 Jedes Quadrat wird nun wiederum in Unter-Quadrate aufgeteilt, die nach der gleichen Logik wie die Felder mit Buchstaben versehen sind, allerdings von AA bis XX. Die DARC-Geschäftsstelle liegt im Feld JO, Quadrat 41, Unter-Quadrat RG.
 
-| X: Bezeichnung | l: Übersetzung | l: Alternative Bez. | c | c: z.B. |
+| X: Bezeichnung | l: Übersetzung | l: Alternative Bez. | c: | c: z.B. |
 | Field | Feld | Größtfeld | AA-RR | JO |
 | Square | Quadrat | Großfeld | 00-99 | 41 |
 | Subsquare | Unter-Quadrat | Kleinfeld | AA-XX | RG |

--- a/contents/sections/morsetelegrafie.md
+++ b/contents/sections/morsetelegrafie.md
@@ -5,7 +5,7 @@ Morsetelegrafie ist das älteste Übertragungsverfahren, das im Funk benutzt wir
 Um verschiedene Zeichen, also Buchstaben, Ziffern und Satzzeichen, zu übertragen, wird der Morsecode verwendet. Für jedes Zeichen ist eine bestimmte Abfolge an kurzen und langen Tönen festgelegt. In den Tabellen [ref:n_morsetelegrafie_morsecode_buchstaben], [ref:n_morsetelegrafie_morsecode_ziffern_satzzeichen] und [ref:n_morsetelegrafie_morsecode_spezial] findet sich ein Teil des Morsecodes. Ein Punkt ([morse:e]) steht für einen kurzen Ton und ein Strich ([morse:t]) für einen langen Ton. Die Decodierung, also die Übersetzung der Töne in Zeichen beim Empfänger, erfolgt mit den Ohren und dem Gehirn - oder heutzutage auch mit dem Computer.
 
 <webmargin>
-| c | l | c | l | c | l |
+| c: | l: | c: | l: | c: | l: |
 |  |  |  |  |  |  |
 | A | [morse:a] | K | [morse:k] | U | [morse:u] |
 | B | [morse:b] | L | [morse:l] | V | [morse:v] |
@@ -21,7 +21,7 @@ Um verschiedene Zeichen, also Buchstaben, Ziffern und Satzzeichen, zu übertrage
 </webmargin>
 
 <webmargin>
-| c | l | c | l | c | l | 
+| c: | l: | c: | l: | c: | l: |
 |  |  |  |  |  |  | 
 | 0 | [morse:0] | 5 | [morse:5] | / | [morse:/] |
 | 1 | [morse:1] | 6 | [morse:6] | . | [morse:.] |
@@ -33,7 +33,7 @@ Um verschiedene Zeichen, also Buchstaben, Ziffern und Satzzeichen, zu übertrage
 </webmargin>
 
 <webmargin>
-| l | l |
+| l: | l: |
 |  |  |
 | Unterbrechung (BK) | [morse:bk] |
 | Trennung innerhalb eines Durchgangs (BT, =) | [morse:=] |

--- a/contents/sections/spannung.md
+++ b/contents/sections/spannung.md
@@ -31,7 +31,7 @@ In der Funktechnik kommen sowohl sehr große als auch sehr kleine Spannungen vor
 Es gibt aber auch Einheitenvorzeichen für sehr kleine Werte. Wir kennen das beispielsweise vom Milliliter (ml): 1 Liter sind 1000 ml. Die wichtigsten Einheitenvorzeichen werden in der Tabelle [ref:n_spannung_einheitenvorzeichen_2] anhand der Einheit Volt vorgestellt. 1 mV ist beispielsweise dasselbe wie 0,001 V. Umgekehrt entsprechen 1000 mV genau 1 V.
 
 <webmargin>
-| l: Spannungsquelle | r | c | l |
+| l: Spannungsquelle | r: | c: | l: |
 | Empfängereingang | 10 μV | = | 0,00001 V |
 | Mikrofon | 200 mV | = | 0,2 V |
 | Batterie | 1,5 V | = | 1,5 V |

--- a/contents/sections/strom.md
+++ b/contents/sections/strom.md
@@ -11,7 +11,7 @@ Die Einheit Ampere ist nach dem französischem Physiker und Mathematiker *André
 Schauen wir uns wieder einige Beispiele an: Durch eine Leuchtdiode (LED) fließen beispielsweise 5 mA Strom. Bei einem Transceiver im Empfangsbetrieb sind es z. B. schon 900 mA, also fast ein Ampere. Durch einen Transceiver im Sendebetrieb kann schon wesentlich mehr Strom fließen, beispielsweise 21 A.
 
 <webmargin>
-| l: Verbraucher | r | c | l |
+| l: Verbraucher | r: | c: | l: |
 | Leuchtdiode (LED) | 5 mA | = | 0,005 A |
 | Transceiver im Empfangsbetrieb | 900 mA | = | 0,9 A |
 | Transceiver im Sendebetrieb | 21 A | = | 21 A |


### PR DESCRIPTION
Add colons to table headers so the alignment characters are not shown as false headers when the column has no text in the heading.