### PR TITLE
Fix: Korrektur der Bildreferenz für Frequenzvervielfacher I (#32)

### DIFF
--- a/contents/sections/frequenzvervielfacher_1.md
+++ b/contents/sections/frequenzvervielfacher_1.md
@@ -5,7 +5,7 @@ Um früher in Amateurfunk-Mehrbandsendern nicht für jeden Frequenzbereich einze
 Abbildung [ref:n_f_vervielfacher] zeigt das Blockschaltbild eines Frequenzvervielfachers mit dem Faktor 2 bei dem die Eingangsfrequenz von $\qty{3,5}{\mega\hertz}$ auf $\qty{7}{\mega\hertz}$ angehoben wird. Ein Frequenzvervielfacher wird dabei typischerweise durch eine Nichtlinearität (z. B. Diode) erzeugt, die gezielt Oberwellen des Eingangssignals erzeugt, aus denen anschließend mit einem Bandpassfilter die gewünschte Vielfachfrequenz ausgewählt wird.
 
 <margin>
-[picture:1043:n_f_vervielfacher:Blockschaltbild eines Frequenzvervielfachers]
+[picture:1042:n_f_vervielfacher:Blockschaltbild eines Frequenzvervielfachers]
 </margin>
 
 Häufig verwendet man eine Kette von Frequenzvervielfachern, um die gewünschten Multiplikationsfaktoren zu erreichen. Hierbei werden bei Reihenschaltung von Vervielfachern die einzelnen Faktoren miteinander multipliziert.


### PR DESCRIPTION
## Beschreibung
In der Lerneinheit "Frequenzvervielfacher I" wurde fälschlicherweise auf die Datei `1043.svg` verwiesen. Gemäß Issue #32 sollte hier das Blockschaltbild `1042.svg` angezeigt werden.

## Änderungen
* Referenz im Markdown von `1043.svg` auf `1042.svg` aktualisiert.

## Verknüpfte Issues
Closes #32