### PR TITLE
fix: section headline for magnetic shielding

### DIFF
--- a/contents/slides/spule_2.md
+++ b/contents/slides/spule_2.md
@@ -173,7 +173,7 @@ $Z = \sqrt{R^2 + X^2}$
 [question:AA101]
 
 ---
-### Abschirmung von elektrischen Feldern
+### Abschirmung von magnetischen Feldern
 
 Ein Gehäuse aus einem magnetisch gut leitfähigem Material.
 


### PR DESCRIPTION
The slide is about shielding of magnetic fields, but the headline references electric fields.