### PR TITLE
Drop anchor in link to images for schwingkreis applet

### DIFF
--- a/contents/html/applet_schwingkreis.html
+++ b/contents/html/applet_schwingkreis.html
@@ -8,7 +8,7 @@
     <script>
         url = new URL(window.location.href);
         url.pathname = url.pathname.replace(/[^/]+$/, 'pictures/');
-        base_url = url.href;
+        base_url = url.href.split("#")[0];
       
         const asgnimage = [
             "891.svg",


### PR DESCRIPTION
This fixes the problem that the animation images are no longer found if the URL contains a reference to an anchor.

Steps to reproduce the problem:
- Go to https://50ohm.de/EA_schwingkreis_1.html
- Confirm that the animation is active
- Click on a reference to an image, e.g. EA-8.1.11
- Refresh the page (shortcut: use this link https://50ohm.de/EA_schwingkreis_1.html#ref_e_rp_schwingkreis)
- Confirm that the images of the animation are not found