### PR TITLE
fix: blauns don't transform impedance

### DIFF
--- a/contents/slides/antenne_laenge_resonanz.md
+++ b/contents/slides/antenne_laenge_resonanz.md
@@ -1,6 +1,6 @@
 * Die Drähte einer Antennen können eine beliebige Länge oder Form haben
 * Jedoch ist dann deren Wellenwiderstand anders
-* Dieser Wellenwiderstand muss an die Speiseleitung angepasst werden, z.B. durch einen Balun
+* Dieser Wellenwiderstand muss an die Speiseleitung angepasst werden, z.B. durch einen HF-Transformator
 
 ---
 [question:EG102]


### PR DESCRIPTION
Balune symmetrieren nur, sie stellen aber keine Anpassung her. Zur Widerstandstransformation braucht es einen Transformator. Beides wird zwar auf Ringkerne gewickelt, aber die Funktionsweise ist eine andere. Beim Balun dämpft der magnetische Fluss Gleichtaktströme. Beim Trafo überträgt der magnetische Fluss die Leistung.